### PR TITLE
disconnect the database after migrations have been performed.

### DIFF
--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -186,6 +186,7 @@ class Manager
                 $this->executeMigration($environment, $migration, MigrationInterface::UP);
             }
         }
+				$env->getAdapter()->disconnect();
     }
 
     /**

--- a/src/Phinx/Migration/Manager.php
+++ b/src/Phinx/Migration/Manager.php
@@ -186,7 +186,7 @@ class Manager
                 $this->executeMigration($environment, $migration, MigrationInterface::UP);
             }
         }
-				$env->getAdapter()->disconnect();
+        $env->getAdapter()->disconnect();
     }
 
     /**


### PR DESCRIPTION
When using many databases, it's possible to create too many connections, and if they are not explicitly closed, they wait until garbage collection, which may be too late to prevent a database problem. Explicitly close each database once the migrations have been run completely.